### PR TITLE
Issue 1635 - Add error return check to prevent crash

### DIFF
--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -7994,7 +7994,12 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 				}
 
 				if (srcInfo != nullptr) {
-					Disassemble(currentAddress[currentCore]);
+					rc = Disassemble(currentAddress[currentCore]);
+					if (rc != TraceDqr::DQERR_OK) {
+						state[currentCore] = TRACE_STATE_GETFIRSTSYNCMSG;
+						readNewTraceMessage = true;
+						break;
+					}
 
 					sourceInfo.coreId = currentCore;
 					*srcInfo = &sourceInfo;


### PR DESCRIPTION
Please Refer Issue 1635 for more details. 
This MR contains the error check to prevent crash during trace decoding.