### PR TITLE
Fix exception suppression on with-sync branch messages.

### DIFF
--- a/src/dqr_interface.cpp
+++ b/src/dqr_interface.cpp
@@ -1034,8 +1034,9 @@ TySifiveTraceDecodeError SifiveDecoderInterface::DecodeBuffer(char* out_file, ch
         {
             msgInfo->messageToText(dst, sizeof dst, msgLevel);
 
-            const bool is_excep_or_intr   = ((strstr(dst, "Branch Type: Exception (2)") != nullptr) || 
-											(strstr(dst, "Branch Type: Interrupt (3)") != nullptr));
+            const TraceDqr::BType bt = msgInfo->getB_Type();
+            const bool is_excep_or_intr   = ((bt == TraceDqr::BTYPE_EXT_EXCEPTION) || 
+											(bt == TraceDqr::BTYPE_EXT_INTERRUPT));
             const bool is_trap0 = (strstr(dst, "TCode: TRAP INFO") != nullptr) &&
                                   (strstr(dst, "Trap Value: 0")   != nullptr);
 


### PR DESCRIPTION
Detect exception/interrupt branch type by field, not message text

The look-ahead in DecodeBuffer() that suppresses the last PC before a
trap entry matched the rendered message text for
"Branch Type: Exception (2)". The with-sync variants format that field
without a colon, so INDIRECT BRANCH WS (27) and INDIRECT BRANCH HISTORY
WS (29) never armed the suppression and the pre-trap instruction was
left in the decoded output.

Read b_type via NexusMessage::getB_Type() and compare against
BTYPE_EXT_EXCEPTION / BTYPE_EXT_INTERRUPT instead. All four
branch-carrying tcodes now behave identically, and the check no longer
depends on message formatting or msgLevel.

No other behaviour changes: the trap-value-0 confirmation, the
look-ahead window and all emitted text are untouched.
